### PR TITLE
Serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,15 @@ repository = "https://github.com/kstep/rust-pocket.git"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-hyper = "0.8.1"
-url = "0.5"
-rustc-serialize = "0.3"
+chrono = "0.4"
+hyper = "0.10.16"
+hyper-native-tls = "0.3.0"
+url = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_derive = "1.0"
+url_serde = "0.2.0"
 mime = "0.2"
-time = "0.1"
 
 [dev-dependencies]
 log = "0.3.5"

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -11,10 +11,10 @@ fn main() {
     );
 
     let item = pocket.add(
-        "http://example.com".into_url().unwrap(),
-        Some("Example"),
-        Some("one,two"),
-        None,
+        "https://example.com".into_url().unwrap(),
+        Some("Example title"),
+        Some("example-tag"),
+        Some("example_tweet_id"),
     ).unwrap();
     println!("item: {:?}", item);
 }

--- a/examples/add.rs
+++ b/examples/add.rs
@@ -1,0 +1,20 @@
+extern crate pocket;
+extern crate hyper;
+
+use pocket::Pocket;
+use hyper::client::IntoUrl;
+
+fn main() {
+    let pocket = Pocket::new(
+        &std::env::var("POCKET_CONSUMER_KEY").unwrap(),
+        Some(&std::env::var("POCKET_ACCESS_TOKEN").unwrap()),
+    );
+
+    let item = pocket.add(
+        "http://example.com".into_url().unwrap(),
+        Some("Example"),
+        Some("one,two"),
+        None,
+    ).unwrap();
+    println!("item: {:?}", item);
+}

--- a/examples/addurl.rs
+++ b/examples/addurl.rs
@@ -6,18 +6,23 @@ use std::io;
 fn main() {
     let mut pocket = Pocket::new(&*option_env!("POCKET_CONSUMER_KEY").unwrap(), None);
     let url = pocket.get_auth_url().unwrap();
-    println!("Follow auth URL to provide access: {}", url);
+    println!("Follow auth URL to provide access and press enter when finished: {}", url);
     let _ = io::stdin().read_line(&mut String::new());
     let username = pocket.authorize().unwrap();
     println!("username: {}", username);
     println!("access token: {:?}", pocket.access_token());
 
-    let item = pocket.push("http://example.com").unwrap();
+    let item = pocket.push("https://example.com").unwrap();
     println!("item: {:?}", item);
 
     let items = {
         let mut f = pocket.filter();
         f.complete();
+        f.archived();
+        f.videos();
+        f.offset(10);
+        f.count(10);
+        f.sort_by_title(); // sorted by title
         pocket.get(&f)
     };
     println!("items: {:?}", items);

--- a/examples/addurl.rs
+++ b/examples/addurl.rs
@@ -18,7 +18,7 @@ fn main() {
     let items = {
         let mut f = pocket.filter();
         f.complete();
-        f.get()
+        pocket.get(&f)
     };
     println!("items: {:?}", items);
 }

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,0 +1,15 @@
+extern crate pocket;
+extern crate hyper;
+
+use pocket::Pocket;
+use std::io;
+
+fn main() {
+    let mut pocket = Pocket::new(&std::env::var("POCKET_CONSUMER_KEY").unwrap(), None);
+    let url = pocket.get_auth_url().unwrap();
+    println!("Follow auth URL to provide access and press enter when finished: {}", url);
+    let _ = io::stdin().read_line(&mut String::new());
+    let username = pocket.authorize().unwrap();
+    println!("username: {}", username);
+    println!("access token: {:?}", pocket.access_token());
+}

--- a/examples/modify.rs
+++ b/examples/modify.rs
@@ -1,0 +1,20 @@
+extern crate pocket;
+extern crate hyper;
+
+use pocket::{Pocket, PocketSendRequest, PocketSendAction};
+
+fn main() {
+    let pocket = Pocket::new(
+        &std::env::var("POCKET_CONSUMER_KEY").unwrap(),
+        Some(&std::env::var("POCKET_ACCESS_TOKEN").unwrap()),
+    );
+    let item_id = std::env::var("POCKET_ITEM_ID").unwrap().parse::<u64>().unwrap();
+
+    let results = pocket.send(&PocketSendRequest {
+        actions: &[
+            &PocketSendAction::Archive { item_id, time: None },
+            &PocketSendAction::TagsAdd { item_id, tags: "one,two".to_string(), time: None },
+        ]
+    }).unwrap();
+    println!("results: {:?}", results);
+}

--- a/examples/modify.rs
+++ b/examples/modify.rs
@@ -2,6 +2,7 @@ extern crate pocket;
 extern crate hyper;
 
 use pocket::{Pocket, PocketSendRequest, PocketSendAction};
+use hyper::client::IntoUrl;
 
 fn main() {
     let pocket = Pocket::new(
@@ -12,8 +13,17 @@ fn main() {
 
     let results = pocket.send(&PocketSendRequest {
         actions: &[
+            &PocketSendAction::Add {
+                item_id: None,
+                ref_id: None,
+                tags: Some("example-tag".to_string()),
+                time: None,
+                title: Some("Example title".to_string()),
+                url: Some("https://example.com".into_url().unwrap()),
+            },
             &PocketSendAction::Archive { item_id, time: None },
             &PocketSendAction::TagsAdd { item_id, tags: "one,two".to_string(), time: None },
+            &PocketSendAction::TagRename { old_tag: "one".to_string(), new_tag: "1".to_string(), time: None },
         ]
     }).unwrap();
     println!("results: {:?}", results);

--- a/examples/retrieve.rs
+++ b/examples/retrieve.rs
@@ -1,0 +1,18 @@
+extern crate pocket;
+
+use pocket::{Pocket, PocketGetRequest};
+
+fn main() {
+    let pocket = Pocket::new(
+        &std::env::var("POCKET_CONSUMER_KEY").unwrap(),
+        Some(&std::env::var("POCKET_ACCESS_TOKEN").unwrap()),
+    );
+
+    let items = {
+        let mut request = PocketGetRequest::new();
+        request.count(10);
+        request.complete();
+        pocket.get(&request)
+    };
+    println!("items: {:?}", items);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -689,8 +689,7 @@ pub enum PocketSendAction {
         time: Option<u64>
     },
     TagDelete {
-        #[serde(serialize_with="to_string")]
-        tag: u64,
+        tag: String,
         #[serde(serialize_with="optional_to_string")]
         time: Option<u64>
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,7 @@ pub struct PocketUserRequest<'a, T> {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PocketGetRequest<'a> {
     search: Option<&'a str>,
     domain: Option<&'a str>,
@@ -347,7 +348,6 @@ pub struct PocketGetRequest<'a> {
     tag: Option<PocketGetTag<'a>>,
     state: Option<PocketGetState>,
     content_type: Option<PocketGetType>,
-    #[serde(rename="detailType")]
     detail_type: Option<PocketGetDetail>,
     #[serde(serialize_with = "optional_bool_to_int")]
     favorite: Option<bool>,
@@ -1108,8 +1108,8 @@ mod test {
                         "domain": "{domain}",
                         "tag": "{tag}",
                         "state": "{state}",
-                        "content_type": "{content_type}",
-                        "detail_type": "{detail_type}",
+                        "contentType": "{content_type}",
+                        "detailType": "{detail_type}",
                         "favorite": "{favorite}",
                         "since": "{since}",
                         "sort": "{sort}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,86 +1,43 @@
 extern crate hyper;
-extern crate rustc_serialize;
 extern crate url;
 extern crate mime;
-extern crate time;
+extern crate chrono;
+extern crate hyper_native_tls;
 
-#[cfg(test)] #[macro_use] extern crate log;
+#[macro_use] extern crate serde_derive;
+extern crate serde;
 
+use hyper_native_tls::NativeTlsClient;
 use hyper::header::{Header, HeaderFormat, ContentType};
-use hyper::client::{Client, IntoUrl};
-use hyper::net::HttpConnector;
+use hyper::client::{Client, IntoUrl, RequestBuilder};
 use hyper::header::parsing::from_one_raw_str;
 use hyper::error::Error as HttpError;
 use url::Url;
 use mime::Mime;
-use rustc_serialize::{json, Decodable, Encodable, Decoder, Encoder};
-use rustc_serialize::json::{ToJson, Json};
 use std::error::Error;
-use std::convert::{From, Into};
+use std::convert::From;
 use std::io::Error as IoError;
 use std::io::Read;
-use std::collections::BTreeMap;
 use std::result::Result;
-use time::Timespec;
-
-pub trait JsonEncodable {
-    fn json_encode(&self, e: &mut json::Encoder) -> Result<(), json::EncoderError>;
-}
-
-pub trait PocketAction : JsonEncodable {
-    fn name(&self) -> &'static str;
-}
-
-impl<T: Encodable> JsonEncodable for T {
-    fn json_encode(&self, e: &mut json::Encoder) -> Result<(), json::EncoderError> {
-        Encodable::encode::<json::Encoder>(self, e)
-    }
-}
-
-macro_rules! impl_item_pocket_action {
-    ($name:expr, $cls:ident) => {
-        pub struct $cls {
-            item_id: u64,
-            time: Option<u64>
-        }
-
-        impl PocketAction for $cls {
-            fn name(&self) -> &'static str { $name }
-        }
-
-        impl JsonEncodable for $cls {
-            fn json_encode(&self, e: &mut json::Encoder) -> Result<(), json::EncoderError> {
-                e.emit_struct(stringify!($cls), 3, |e| {
-                    e.emit_struct_field("name", 0, |e| e.emit_str(self.name())).and_then(|_|
-                    e.emit_struct_field("item_id", 1, |e| e.emit_u64(self.item_id))).and_then(|_|
-                    e.emit_struct_field("time", 2, |e| match self.time {
-                        Some(v) => e.emit_option_some(|e| e.emit_u64(v)),
-                        None => e.emit_option_none()
-                    }))
-                })
-            }
-        }
-    }
-}
+use serde::{Deserialize, Deserializer, Serializer};
+use serde::de::{DeserializeOwned, Unexpected};
+use std::str::FromStr;
+use std::fmt::Display;
+use std::collections::HashMap;
+use chrono::{DateTime, Utc};
+use hyper::net::HttpsConnector;
 
 #[derive(Debug)]
 pub enum PocketError {
     Http(HttpError),
-    Json(json::DecoderError),
-    Format(json::EncoderError),
+    Json(serde_json::Error),
     Proto(u16, String)
 }
 
 pub type PocketResult<T> = Result<T, PocketError>;
 
-impl From<json::EncoderError> for PocketError {
-    fn from(err: json::EncoderError) -> PocketError {
-        PocketError::Format(err)
-    }
-}
-
-impl From<json::DecoderError> for PocketError {
-    fn from(err: json::DecoderError) -> PocketError {
+impl From<serde_json::Error> for PocketError {
+    fn from(err: serde_json::Error) -> PocketError {
         PocketError::Json(err)
     }
 }
@@ -102,16 +59,14 @@ impl Error for PocketError {
         match *self {
             PocketError::Http(ref e) => e.description(),
             PocketError::Json(ref e) => e.description(),
-            PocketError::Format(ref e) => e.description(),
             PocketError::Proto(..) => "protocol error"
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             PocketError::Http(ref e) => Some(e),
             PocketError::Json(ref e) => Some(e),
-            PocketError::Format(ref e) => Some(e),
             PocketError::Proto(..) => None
         }
     }
@@ -122,7 +77,6 @@ impl std::fmt::Display for PocketError {
         match *self {
             PocketError::Http(ref e) => e.fmt(fmt),
             PocketError::Json(ref e) => e.fmt(fmt),
-            PocketError::Format(ref e) => e.fmt(fmt),
             PocketError::Proto(ref code, ref msg) => fmt.write_str(&*format!("{} (code {})", msg, code))
         }
     }
@@ -204,235 +158,213 @@ pub struct Pocket {
     client: Client
 }
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 pub struct PocketOAuthRequest<'a> {
     consumer_key: &'a str,
     redirect_uri: &'a str,
     state: Option<&'a str>
 }
 
-#[derive(RustcDecodable)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct PocketOAuthResponse {
     code: String,
     state: Option<String>
 }
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 pub struct PocketAuthorizeRequest<'a> {
     consumer_key: &'a str,
     code: &'a str
 }
 
-#[derive(RustcDecodable)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct PocketAuthorizeResponse {
     access_token: String,
     username: String
 }
 
-#[derive(RustcEncodable)]
-pub struct PocketAddRequest<'a> {
-    consumer_key: &'a str,
-    access_token: &'a str,
-    url: &'a Url,
-    title: Option<&'a str>,
-    tags: Option<&'a str>,
-    tweet_id: Option<&'a str>
+#[derive(Serialize)]
+struct PocketAddRequest<'a> {
+    #[serde(with = "url_serde")]
+    pub url: url::Url, // TODO - borrow
+    pub title: Option<&'a str>,
+    pub tags: Option<&'a str>, // TODO - make vec or array
+    pub tweet_id: Option<&'a str>
 }
 
-
-#[derive(RustcDecodable, Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct ItemImage {
-    pub item_id: u64, // String
-    pub image_id: u64, // String
+    #[serde(deserialize_with = "from_str")]
+    pub item_id: u64,
+    #[serde(deserialize_with = "from_str")]
+    pub image_id: u64,
+    #[serde(with = "url_serde")]
     pub src: Url,
-    pub width: u16, // String
-    pub height: u16, // String
-    pub caption: String,
+    #[serde(deserialize_with = "from_str")]
+    pub width: u16,
+    #[serde(deserialize_with = "from_str")]
+    pub height: u16,
     pub credit: String,
+    pub caption: String,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq, Clone)]
+pub struct DomainMetaData {
+    pub name: String,
+    pub logo: String,
+    pub greyscale_logo: String,
+}
+
+#[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct ItemVideo {
-    pub item_id: u64, // String
-    pub video_id: u64, // String
+    #[serde(deserialize_with = "from_str")]
+    pub item_id: u64,
+    #[serde(deserialize_with = "from_str")]
+    pub video_id: u64,
+    #[serde(with = "url_serde")]
     pub src: Url,
-    pub width: u16, // String
-    pub height: u16, // String
-    pub length: Option<usize>, // String
+    #[serde(deserialize_with = "from_str")]
+    pub width: u16,
+    #[serde(deserialize_with = "from_str")]
+    pub height: u16,
+    #[serde(deserialize_with = "option_from_str")]
+    pub length: Option<usize>,
     pub vid: String,
+    #[serde(rename="type")]
     pub vtype: u16,
 }
 
-impl Decodable for ItemVideo {
-    fn decode<D: Decoder>(d: &mut D) -> Result<ItemVideo, D::Error> {
-        d.read_struct("ItemVideo", 0, |d| Ok(ItemVideo {
-            item_id: try!(d.read_struct_field("item_id", 0, |d| d.read_u64())),
-            video_id: try!(d.read_struct_field("video_id", 1, |d| d.read_u64())),
-            src: try!(d.read_struct_field("src", 2, Decodable::decode)),
-            width: try!(d.read_struct_field("width", 3, |d| d.read_u16())),
-            height: try!(d.read_struct_field("height", 4, |d| d.read_u16())),
-            length: try!(d.read_struct_field("length", 5, |d| d.read_option(|d, b| if b { d.read_usize().map(|v| Some(v)) } else { Ok(None) }))),
-            vid: try!(d.read_struct_field("vid", 6, |d| d.read_str())),
-            vtype: try!(d.read_struct_field("type", 7, |d| d.read_u16())),
-        }))
-    }
+#[derive(Deserialize, Debug, PartialEq, Clone)]
+pub struct ItemAuthor {
+    #[serde(deserialize_with = "from_str")]
+    pub item_id: u64,
+    #[serde(deserialize_with = "from_str")]
+    pub author_id: u64,
+    pub name: String,
+    pub url: String,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Deserialize, Debug, PartialEq, Clone, Copy)]
 pub enum PocketItemHas {
-    No = 0,
-    Yes = 1,
-    Is = 2
+    #[serde(rename="0")]
+    No,
+    #[serde(rename="1")]
+    Yes,
+    #[serde(rename="2")]
+    Is
 }
 
-impl Decodable for PocketItemHas {
-    fn decode<D: Decoder>(d: &mut D) -> Result<PocketItemHas, D::Error> {
-        d.read_u8().map(|v| match v {
-            0 => PocketItemHas::No,
-            1 => PocketItemHas::Yes,
-            2 => PocketItemHas::Is,
-            _ => unreachable!()
-        })
-    }
-}
-
-#[derive(Debug, PartialEq)]
+// TODO - compare with PocketItem
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct PocketAddedItem {
-    pub item_id: u64, // String
-    pub extended_item_id: u64, // String
+    #[serde(deserialize_with = "from_str")]
+    pub item_id: u64,
 
-    pub given_url: Url,
+    #[serde(with = "url_serde")]
     pub normal_url: Url,
-    pub content_length: usize, // String
-    pub word_count: usize, // String
-    pub encoding: String,
+
+    #[serde(deserialize_with = "from_str")]
+    pub resolved_id: u64,
+
+    #[serde(deserialize_with = "from_str")]
+    pub extended_item_id: u64,
+
+    #[serde(with = "url_serde")]
+    pub resolved_url: Url,
+
+    #[serde(deserialize_with = "from_str")]
+    pub domain_id: u64,
+    #[serde(deserialize_with = "from_str")]
+    pub origin_domain_id: u64,
+
+    #[serde(deserialize_with = "from_str")]
+    pub response_code: u16,
+
     pub mime_type: String, // must be Option<Mime>
-    pub lang: String,
+
+    #[serde(deserialize_with = "from_str")]
+    pub content_length: usize,
+
+    pub encoding: String,
+    pub date_resolved: String, // TODO - 2020-03-02 14:51:51
+    pub date_published: String, // TODO - 0000-00-00 00:00:00
+
     pub title: String,
     pub excerpt: String,
 
-    pub date_published: String, // must be Tm or Timespec
-    pub date_resolved: String, // must be Tm or Timespec
+    #[serde(deserialize_with = "from_str")]
+    pub word_count: usize,
 
-    pub resolved_id: u64, // String
-    pub resolved_url: Url,
-    pub resolved_normal_url: Url,
+    // TODO - innerdomain_redirect 1
 
-    pub login_required: bool, // String
-    pub response_code: u16,
-    pub used_fallback: bool, // String
+    #[serde(deserialize_with = "bool_from_int")]
+    pub login_required: bool,
 
-    pub domain_id: u64, // String
-    pub origin_domain_id: u64, // String
-    pub innerdomain_redirect: bool,
+    pub has_image: PocketItemHas,
+    pub has_video: PocketItemHas,
 
-    pub is_index: bool, // String
-    pub is_article: bool, // String
-    pub has_image: PocketItemHas, // String
-    pub has_video: PocketItemHas, // String
+    #[serde(deserialize_with = "bool_from_int")]
+    pub is_index: bool,
+    #[serde(deserialize_with = "bool_from_int")]
+    pub is_article: bool,
 
-    //pub tags: Vec<ItemTag>, // ???
-    //pub authors: Vec<ItemAuthor>, // ???
-    pub videos: Vec<ItemVideo>, // encoded as object with integer indices
-    pub images: Vec<ItemImage>, // if present, as empty array otherwise
+    #[serde(deserialize_with = "bool_from_int")]
+    pub used_fallback: bool,
+
+    pub lang: String,
+
+    // TODO - time_first_parsed 0
+
+    pub authors: Vec<ItemAuthor>,
+    pub images: Vec<ItemImage>,
+
+    pub videos: Vec<ItemVideo>,
+
+    #[serde(with = "url_serde")]
+    pub given_url: Url,
 }
 
-impl Decodable for PocketAddedItem {
-    fn decode<D: Decoder>(d: &mut D) -> Result<PocketAddedItem, D::Error> {
-        d.read_struct("PocketAddedItem", 28, |d| Ok(PocketAddedItem {
-            item_id: try!(d.read_struct_field("item_id", 0, |d| d.read_u64())),
-            extended_item_id: try!(d.read_struct_field("extended_item_id", 1, |d| d.read_u64())),
-
-            given_url: try!(d.read_struct_field("given_url", 2, Decodable::decode)),
-            normal_url: try!(d.read_struct_field("normal_url", 3, Decodable::decode)),
-            content_length: try!(d.read_struct_field("content_length", 4, |d| d.read_usize())),
-            word_count: try!(d.read_struct_field("word_count", 5, |d| d.read_usize())),
-            encoding: try!(d.read_struct_field("encoding", 6, |d| d.read_str())),
-            mime_type: try!(d.read_struct_field("mime_type", 7, |d| d.read_str())),
-            lang: try!(d.read_struct_field("lang", 8, |d| d.read_str())),
-            title: try!(d.read_struct_field("title", 9, |d| d.read_str())),
-            excerpt: try!(d.read_struct_field("excerpt", 10, |d| d.read_str())),
-
-            date_published: try!(d.read_struct_field("date_published", 11, |d| d.read_str())),
-            date_resolved: try!(d.read_struct_field("date_resolved", 12, |d| d.read_str())),
-
-            resolved_id: try!(d.read_struct_field("resolved_id", 13, |d| d.read_u64())),
-            resolved_url: try!(d.read_struct_field("resolved_url", 14, Decodable::decode)),
-            resolved_normal_url: try!(d.read_struct_field("resolved_normal_url", 15, Decodable::decode)),
-
-            login_required: try!(d.read_struct_field("login_required", 16, |d| d.read_u8().map(|v| v != 0))),
-            response_code: try!(d.read_struct_field("response_code", 17, |d| d.read_u16())),
-            used_fallback: try!(d.read_struct_field("used_fallback", 18, |d| d.read_u8().map(|v| v != 0))),
-
-            domain_id: try!(d.read_struct_field("domain_id", 19, |d| d.read_u64())),
-            origin_domain_id: try!(d.read_struct_field("origin_domain_id", 20, |d| d.read_u64())),
-            innerdomain_redirect: try!(d.read_struct_field("innerdomain_redirect", 21, |d| d.read_u8().map(|v| v != 0))),
-
-            is_index: try!(d.read_struct_field("is_index", 22, |d| d.read_u8().map(|v| v != 0))),
-            is_article: try!(d.read_struct_field("is_article", 23, |d| d.read_u8().map(|v| v != 0))),
-            has_image: try!(d.read_struct_field("has_image", 24, Decodable::decode)),
-            has_video: try!(d.read_struct_field("has_video", 25, Decodable::decode)),
-
-            videos: try!(d.read_struct_field("videos", 26, |d| d.read_seq(|d, s|
-                Ok((0..s).flat_map(|i| d.read_seq_elt(i, Decodable::decode)).into_iter().collect())
-            ))),
-            images: try!(d.read_struct_field("images", 27, |d| d.read_seq(|d, s|
-                Ok((0..s).flat_map(|i| d.read_seq_elt(i, Decodable::decode)).into_iter().collect())
-            )))
-        }))
-    }
-}
-
-#[derive(RustcDecodable)]
+#[derive(Deserialize, Debug)]
 pub struct PocketAddResponse {
-    item: PocketAddedItem,
-    status: u16
+    pub item: PocketAddedItem,
+    pub status: u16
 }
 
-pub struct PocketGetRequest<'a> {
-    pocket: &'a mut Pocket,
+#[derive(Serialize)]
+pub struct PocketUserRequest<'a, T> {
+    consumer_key: &'a str,
+    access_token: &'a str,
 
+    #[serde(flatten)]
+    request: T,
+}
+
+#[derive(Serialize)]
+pub struct PocketGetRequest<'a> {
     search: Option<&'a str>,
     domain: Option<&'a str>,
 
     tag: Option<PocketGetTag<'a>>,
     state: Option<PocketGetState>,
     content_type: Option<PocketGetType>,
+    #[serde(rename="detailType")]
     detail_type: Option<PocketGetDetail>,
+    #[serde(serialize_with = "optional_bool_to_int")]
     favorite: Option<bool>,
-    since: Option<Timespec>,
+
+    #[serde(serialize_with = "optional_datetime_to_int")]
+    since: Option<DateTime<Utc>>,
 
     sort: Option<PocketGetSort>,
+    #[serde(serialize_with = "optional_to_string")]
     count: Option<usize>,
+    #[serde(serialize_with = "optional_to_string")]
     offset: Option<usize>
 }
 
-impl<'a> Encodable for PocketGetRequest<'a> {
-    fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
-        e.emit_struct("PocketGetRequest", 13, |e| {
-            e.emit_struct_field("consumer_key", 0, |e| self.pocket.consumer_key.encode(e)).and_then(|_|
-            e.emit_struct_field("access_token", 1, |e| self.pocket.access_token.as_ref().unwrap().encode(e))).and_then(|_|
-            e.emit_struct_field("search", 2, |e| self.search.encode(e))).and_then(|_|
-            e.emit_struct_field("domain", 3, |e| self.domain.encode(e))).and_then(|_|
-
-            e.emit_struct_field("tag", 4, |e| self.tag.encode(e))).and_then(|_|
-            e.emit_struct_field("state", 5, |e| self.state.encode(e))).and_then(|_|
-            e.emit_struct_field("content_type", 6, |e| self.content_type.encode(e))).and_then(|_|
-            e.emit_struct_field("detail_type", 7, |e| self.detail_type.encode(e))).and_then(|_|
-            e.emit_struct_field("favorite", 8, |e| self.favorite.encode(e))).and_then(|_|
-            e.emit_struct_field("since", 9, |e| self.since.map(|v| v.sec).encode(e))).and_then(|_|
-
-            e.emit_struct_field("sort", 10, |e| self.sort.encode(e))).and_then(|_|
-            e.emit_struct_field("count", 11, |e| self.count.encode(e))).and_then(|_|
-            e.emit_struct_field("offset", 12, |e| self.offset.encode(e)))
-        })
-    }
-}
-
 impl<'a> PocketGetRequest<'a> {
-    fn new(pocket: &'a mut Pocket) -> PocketGetRequest<'a> {
+    pub fn new() -> PocketGetRequest<'a> {
         PocketGetRequest {
-            pocket: pocket,
             search: None,
             domain: None,
             tag: None,
@@ -510,7 +442,7 @@ impl<'a> PocketGetRequest<'a> {
         self
     }
 
-    pub fn since<'b>(&'b mut self, since: Timespec) -> &'b mut PocketGetRequest<'a> {
+    pub fn since<'b>(&'b mut self, since: DateTime<Utc>) -> &'b mut PocketGetRequest<'a> {
         self.since = Some(since);
         self
     }
@@ -549,35 +481,17 @@ impl<'a> PocketGetRequest<'a> {
     pub fn slice<'b>(&'b mut self, offset: usize, count: usize) -> &'b mut PocketGetRequest<'a> {
         self.offset(offset).count(count)
     }
-
-    pub fn get(self) -> PocketResult<Vec<PocketItem>> {
-        let mut request = String::new();
-        {
-            let mut encoder = json::Encoder::new(&mut request);
-            self.encode(&mut encoder).unwrap();
-        }
-
-        self.pocket.request("https://getpocket.com/v3/get", &*request)
-            .map(|v: PocketGetResponse| v.list)
-    }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Serialize, Debug, Clone, Copy)]
+#[serde(rename_all="lowercase")]
 pub enum PocketGetDetail {
     Simple,
     Complete
 }
 
-impl Encodable for PocketGetDetail {
-    fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
-        e.emit_str(match *self {
-            PocketGetDetail::Simple => "simple",
-            PocketGetDetail::Complete => "complete",
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
+#[derive(Serialize, Debug, Clone, Copy)]
+#[serde(rename_all="lowercase")]
 pub enum PocketGetSort {
     Newest,
     Oldest,
@@ -585,320 +499,220 @@ pub enum PocketGetSort {
     Site
 }
 
-impl Encodable for PocketGetSort {
-    fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
-        e.emit_str(match *self {
-            PocketGetSort::Newest => "newest",
-            PocketGetSort::Oldest => "oldest",
-            PocketGetSort::Title => "title",
-            PocketGetSort::Site => "site"
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
+#[derive(Serialize, Debug, Clone, Copy)]
+#[serde(rename_all="lowercase")]
 pub enum PocketGetState {
     Unread,
     Archive,
     All
 }
 
-impl Encodable for PocketGetState {
-    fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
-        e.emit_str(match *self {
-            PocketGetState::Unread => "unread",
-            PocketGetState::Archive => "archive",
-            PocketGetState::All => "all"
-        })
-    }
-}
-
-#[derive(Debug)]
+#[derive(Serialize, Debug)]
+#[serde(untagged)]
 pub enum PocketGetTag<'a> {
+    #[serde(serialize_with="untagged_to_str")]
     Untagged,
     Tagged(&'a str)
 }
 
-impl<'a> Encodable for PocketGetTag<'a> {
-    fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
-        e.emit_str(match *self {
-            PocketGetTag::Untagged => "_untagged_",
-            PocketGetTag::Tagged(ref s) => s
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
+#[derive(Serialize, Debug, Clone, Copy)]
+#[serde(rename_all="lowercase")]
 pub enum PocketGetType {
     Article,
     Video,
     Image
 }
 
-impl Encodable for PocketGetType {
-    fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
-        e.emit_str(match *self {
-            PocketGetType::Article => "article",
-            PocketGetType::Video => "video",
-            PocketGetType::Image => "image",
-        })
-    }
+#[derive(Deserialize, Debug)]
+struct PocketSearchMeta {
+    search_type: String
 }
 
-#[derive(Debug)]
-pub struct PocketGetResponse {
-    list: Vec<PocketItem>, // must be Vec
+#[derive(Deserialize, Debug)]
+struct PocketGetResponse {
+    #[serde(deserialize_with = "vec_from_map")]
+    list: Vec<PocketItem>,
     status: u16,
-    complete: bool, // must be bool
+    complete: u16, // TODO - map to bool
     error: Option<String>,
-    //search_meta: PocketSearchMeta,
-    since: Timespec,
+    search_meta: PocketSearchMeta,
+    // TODO - deserialize option datetime utc
+    //since: Option<DateTime<Utc>>
 }
 
-impl Decodable for PocketGetResponse {
-    fn decode<D: Decoder>(d: &mut D) -> Result<PocketGetResponse, D::Error> {
-        d.read_struct("PocketGetResponse", 5, |d| Ok(PocketGetResponse {
-            list: try!(d.read_struct_field("list", 0, |d| d.read_map(|d, s|
-                Ok((0..s).flat_map(|i|
-                    d.read_map_elt_key(i, |d| d.read_str()).and_then(|_|
-                    d.read_map_elt_val(i, Decodable::decode)).into_iter())
-                .collect())
-            ))),
-            status: try!(d.read_struct_field("status", 1, |d| d.read_u16())),
-            complete: try!(d.read_struct_field("complete", 2, |d| d.read_u8().map(|v| v != 0))),
-            error: try!(d.read_struct_field("error", 3, |d| d.read_option(|d, b| if b { d.read_str().map(Some) } else { Ok(None) }))),
-            since: try!(d.read_struct_field("since", 4, |d| d.read_u64().map(|v| Timespec::new(v as i64, 0))))
-        }))
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Deserialize, Debug, PartialEq, Clone, Copy)]
 pub enum PocketItemStatus {
-    Normal = 0,
-    Archived = 1,
-    Deleted = 2
+    #[serde(rename="0")]
+    Normal,
+    #[serde(rename="1")]
+    Archived,
+    #[serde(rename="2")]
+    Deleted
 }
 
-impl Decodable for PocketItemStatus {
-    fn decode<D: Decoder>(d: &mut D) -> Result<PocketItemStatus, D::Error> {
-        d.read_u8().map(|v| match v {
-            0 => PocketItemStatus::Normal,
-            1 => PocketItemStatus::Archived,
-            2 => PocketItemStatus::Deleted,
-            _ => unreachable!()
-        })
-    }
-}
-
-// See also PocketAddedItem
-#[derive(Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct PocketItem {
+    #[serde(deserialize_with = "from_str")]
     pub item_id: u64,
 
+    #[serde(with = "url_serde")]
     pub given_url: Url,
     pub given_title: String,
 
+    #[serde(deserialize_with = "from_str")]
     pub word_count: usize,
     pub excerpt: String,
 
-    pub time_added: Timespec,
-    pub time_read: Timespec,
-    pub time_updated: Timespec,
-    pub time_favorited: Timespec,
+    #[serde(with="date_unix_timestamp_format")]
+    pub time_added: DateTime<Utc>,
+    #[serde(with="date_unix_timestamp_format")]
+    pub time_read: DateTime<Utc>,
+    #[serde(with="date_unix_timestamp_format")]
+    pub time_updated: DateTime<Utc>, // TODO - change to None if zero?
+    #[serde(with="date_unix_timestamp_format")]
+    pub time_favorited: DateTime<Utc>,
 
+    #[serde(deserialize_with="bool_from_int")]
     pub favorite: bool,
 
+    #[serde(deserialize_with="bool_from_int")]
     pub is_index: bool,
+    #[serde(deserialize_with="bool_from_int")]
     pub is_article: bool,
     pub has_image: PocketItemHas,
     pub has_video: PocketItemHas,
 
+    #[serde(deserialize_with = "from_str")]
     pub resolved_id: u64,
     pub resolved_title: String,
-    pub resolved_url: Url,
+    pub resolved_url: String, // not always a valid url
 
-    pub sort_id: usize,
+    pub sort_id: u64,
 
     pub status: PocketItemStatus,
+    #[serde(default, deserialize_with = "optional_vec_from_map")]
     pub images: Option<Vec<ItemImage>>,
+    #[serde(default, deserialize_with = "optional_vec_from_map")]
     pub videos: Option<Vec<ItemVideo>>,
+    #[serde(default, deserialize_with = "optional_vec_from_map")]
+    pub authors: Option<Vec<ItemAuthor>>,
+    pub lang: String,
+    pub time_to_read: Option<u64>,
+    pub domain_metadata: Option<DomainMetaData>,
+    pub listen_duration_estimate: Option<u64>,
+
+    // pub image: Option<ItemImage>, // TODO - does not have image_id
+    // TODO - amp_url
+    // TODO - top_image_url
 }
 
-impl Decodable for PocketItem {
-    fn decode<D: Decoder>(d: &mut D) -> Result<PocketItem, D::Error> {
-        d.read_struct("PocketItem", 21, |d| Ok(PocketItem {
-            item_id: try!(d.read_struct_field("item_id", 0, |d| d.read_u64())),
-
-            given_url: try!(d.read_struct_field("given_url", 1, Decodable::decode)),
-            given_title: try!(d.read_struct_field("given_title", 2, |d| d.read_str())),
-
-            word_count: try!(d.read_struct_field("word_count", 3, |d| d.read_usize())),
-            excerpt: try!(d.read_struct_field("excerpt", 4, |d| d.read_str())),
-
-            time_added: try!(d.read_struct_field("time_added", 5, |d| d.read_u64().map(|v| Timespec::new(v as i64, 0)))),
-            time_read: try!(d.read_struct_field("time_read", 6, |d| d.read_u64().map(|v| Timespec::new(v as i64, 0)))),
-            time_updated: try!(d.read_struct_field("time_updated", 7, |d| d.read_u64().map(|v| Timespec::new(v as i64, 0)))),
-            time_favorited: try!(d.read_struct_field("time_favorited", 8, |d| d.read_u64().map(|v| Timespec::new(v as i64, 0)))),
-
-            favorite: try!(d.read_struct_field("favorite", 9, |d| d.read_u8().map(|v| v != 0))),
-            is_index: try!(d.read_struct_field("is_index", 10, |d| d.read_u8().map(|v| v != 0))),
-            is_article: try!(d.read_struct_field("is_article", 11, |d| d.read_u8().map(|v| v != 0))),
-            has_image: try!(d.read_struct_field("has_image", 12, Decodable::decode)),
-            has_video: try!(d.read_struct_field("has_video", 13, Decodable::decode)),
-
-            resolved_id: try!(d.read_struct_field("resolved_id", 14, |d| d.read_u64())),
-            resolved_title: try!(d.read_struct_field("resolved_title", 15, |d| d.read_str())),
-            resolved_url: try!(d.read_struct_field("resolved_url", 16, Decodable::decode)),
-
-            sort_id: try!(d.read_struct_field("sort_id", 17, |d| d.read_usize())),
-            status: try!(d.read_struct_field("status", 18, Decodable::decode)),
-
-            videos: try!(d.read_struct_field("videos", 19, |d| d.read_option(|d, b| if b {
-                d.read_map(|d, s| Ok((0..s).flat_map(|i| d.read_map_elt_val(i, Decodable::decode).into_iter()).collect())).map(Some)
-            } else {
-                Ok(None)
-            }))),
-            images: try!(d.read_struct_field("images", 20, |d| d.read_option(|d, b| if b {
-                d.read_map(|d, s| Ok((0..s).flat_map(|i| d.read_map_elt_val(i, Decodable::decode).into_iter()).collect())).map(Some)
-            } else {
-                Ok(None)
-            })))
-        }))
-    }
+#[derive(Serialize)]
+pub struct PocketSendRequest<'a> {
+    pub actions: &'a [&'a PocketSendAction]
 }
 
-pub struct PocketAddAction<'a> {
-    item_id: Option<u64>,
-    ref_id: Option<&'a str>,
-    tags: Option<&'a str>,
-    time: Option<u64>,
-    title: Option<&'a str>,
-    url: Option<&'a Url>
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum PocketSendAction {
+    Add {
+        #[serde(serialize_with="optional_to_string")]
+        item_id: Option<u64>,
+        ref_id: Option<String>,
+        tags: Option<String>,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>,
+        title: Option<String>,
+        #[serde(with = "url_serde")]
+        url: Option<Url>
+    },
+    Archive {
+        #[serde(serialize_with="to_string")]
+        item_id: u64,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>
+    },
+    Readd {
+        #[serde(serialize_with="to_string")]
+        item_id: u64,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>
+    },
+    Favorite {
+        #[serde(serialize_with="to_string")]
+        item_id: u64,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>
+    },
+    Unfavorite {
+        #[serde(serialize_with="to_string")]
+        item_id: u64,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>
+    },
+    Delete {
+        #[serde(serialize_with="to_string")]
+        item_id: u64,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>
+    } ,
+    TagsAdd {
+        #[serde(serialize_with="to_string")]
+        item_id: u64,
+        tags: String,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>
+    },
+    TagsRemove {
+        #[serde(serialize_with="to_string")]
+        item_id: u64,
+        tags: String,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>
+    },
+    TagsReplace {
+        #[serde(serialize_with="to_string")]
+        item_id: u64,
+        tags: String,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>
+    },
+    TagsClear {
+        #[serde(serialize_with="to_string")]
+        item_id: u64,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>
+    },
+    TagRename {
+        old_tag: String,
+        new_tag: String,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>
+    },
+    TagDelete {
+        #[serde(serialize_with="to_string")]
+        tag: u64,
+        #[serde(serialize_with="optional_to_string")]
+        time: Option<u64>
+    },
 }
 
-impl<'a> PocketAction for PocketAddAction<'a> {
-    fn name(&self) -> &'static str { "add" }
-}
-
-impl<'a> JsonEncodable for PocketAddAction<'a> {
-    fn json_encode(&self, e: &mut json::Encoder) -> Result<(), json::EncoderError> {
-        e.emit_struct("PocketAddAction", 7, |e| {
-            e.emit_struct_field("name", 0, |e| e.emit_str(self.name())).and_then(|_|
-            e.emit_struct_field("item_id", 1, |e| self.item_id.encode(e))).and_then(|_|
-            e.emit_struct_field("ref_id", 2, |e| self.ref_id.encode(e))).and_then(|_|
-            e.emit_struct_field("tags", 3, |e| self.tags.encode(e))).and_then(|_|
-            e.emit_struct_field("time", 4, |e| self.time.encode(e))).and_then(|_|
-            e.emit_struct_field("title", 5, |e| self.title.encode(e))).and_then(|_|
-            e.emit_struct_field("url", 6, |e| self.url.encode(e)))
-        })
-    }
-}
-
-impl_item_pocket_action!("archive", PocketArchiveAction);
-impl_item_pocket_action!("readd", PocketReaddAction);
-impl_item_pocket_action!("favorite", PocketFavoriteAction);
-impl_item_pocket_action!("unfavorite", PocketUnfavoriteAction);
-impl_item_pocket_action!("delete", PocketDeleteAction);
-
-pub struct PocketTagsAddAction<'a> {
-    item_id: u64,
-    tags: &'a str,
-    time: Option<u64>,
-}
-
-impl<'a> PocketAction for PocketTagsAddAction<'a> {
-    fn name(&self) -> &'static str { "tags_add" }
-}
-
-impl<'a> JsonEncodable for PocketTagsAddAction<'a> {
-    fn json_encode(&self, e: &mut json::Encoder) -> Result<(), json::EncoderError> {
-        e.emit_struct("PocketTagsAddAction", 3, |e| {
-            e.emit_struct_field("name", 0, |e| e.emit_str(self.name())).and_then(|_|
-            e.emit_struct_field("tags", 1, |e| self.tags.encode(e))).and_then(|_|
-            e.emit_struct_field("time", 2, |e| self.time.encode(e)))
-        })
-    }
-}
-
-pub struct PocketTagsReplaceAction<'a> {
-    item_id: u64,
-    tags: &'a str,
-    time: Option<u64>,
-}
-
-impl<'a> PocketAction for PocketTagsReplaceAction<'a> {
-    fn name(&self) -> &'static str { "tags_replace" }
-}
-
-impl<'a> JsonEncodable for PocketTagsReplaceAction<'a> {
-    fn json_encode(&self, e: &mut json::Encoder) -> Result<(), json::EncoderError> {
-        e.emit_struct("PocketTagsReplaceAction", 4, |e| {
-            e.emit_struct_field("name", 0, |e| e.emit_str(self.name())).and_then(|_|
-            e.emit_struct_field("item_id", 1, |e| self.item_id.encode(e))).and_then(|_|
-            e.emit_struct_field("tags", 2, |e| self.tags.encode(e))).and_then(|_|
-            e.emit_struct_field("time", 3, |e| self.time.encode(e)))
-        })
-    }
-}
-
-impl_item_pocket_action!("tags_clear", PocketTagsClearAction);
-
-pub struct PocketTagRenameAction<'a> {
-    item_id: u64,
-    old_tag: &'a str,
-    new_tag: &'a str,
-    time: Option<u64>,
-}
-
-impl<'a> PocketAction for PocketTagRenameAction<'a> {
-    fn name(&self) -> &'static str { "tag_rename" }
-}
-
-impl<'a> JsonEncodable for PocketTagRenameAction<'a> {
-    fn json_encode(&self, e: &mut json::Encoder) -> Result<(), json::EncoderError> {
-        e.emit_struct("PocketTagRenameAction", 5, |e| {
-            e.emit_struct_field("name", 0, |e| e.emit_str(self.name())).and_then(|_|
-            e.emit_struct_field("item_id", 1, |e| self.item_id.encode(e))).and_then(|_|
-            e.emit_struct_field("old_tag", 2, |e| self.old_tag.encode(e))).and_then(|_|
-            e.emit_struct_field("new_tag", 3, |e| self.new_tag.encode(e))).and_then(|_|
-            e.emit_struct_field("time", 4, |e| self.time.encode(e)))
-        })
-    }
-}
-
-pub struct PocketSendRequest<'a, 'b> {
-    pocket: &'b mut Pocket,
-    actions: &'a [&'a PocketAction]
-}
-
-impl<'a, 'b> JsonEncodable for PocketSendRequest<'a, 'b> {
-    fn json_encode(&self, e: &mut json::Encoder) -> Result<(), json::EncoderError> {
-        e.emit_struct("PocketSendRequest", 3, |e| {
-            e.emit_struct_field("consumer_key", 0, |e| self.pocket.consumer_key.encode(e)).and_then(|_|
-            e.emit_struct_field("access_token", 1, |e| self.pocket.access_token.as_ref().unwrap().encode(e))).and_then(|_|
-            e.emit_struct_field("actions", 2, |e| e.emit_seq(self.actions.len(), |e| {
-                for (i, action) in self.actions.iter().enumerate() {
-                    try!(e.emit_seq_elt(i, |e| action.json_encode(e)));
-                }
-                Ok(())
-            })))
-        })
-    }
-}
-
-#[derive(RustcDecodable)]
+#[derive(Deserialize, Debug)]
 pub struct PocketSendResponse {
-    status: u16,
-    action_results: Vec<bool>
+    pub status: u16,
+    pub action_results: Vec<bool>
+    // TODO - action_errors []
 }
 
 impl Pocket {
     pub fn new(consumer_key: &str, access_token: Option<&str>) -> Pocket {
+        let ssl = NativeTlsClient::new().unwrap();
+        let connector = HttpsConnector::new(ssl);
+
         Pocket {
             consumer_key: consumer_key.to_string(),
             access_token: access_token.map(|v| v.to_string()),
             code: None,
-            client: Client::new()
+            client: Client::with_connector(connector)
         }
     }
 
@@ -906,47 +720,58 @@ impl Pocket {
         self.access_token.as_ref().map(|v| &**v)
     }
 
-    fn request<Resp: Decodable>(&mut self, url: &str, data: &str) -> PocketResult<Resp> {
-        let app_json: Mime = "application/json".parse().unwrap();
-        self.client.post(url)
-            .header(XAccept(app_json.clone()))
-            .header(ContentType(app_json.clone()))
-            .body(data)
-            .send().map_err(From::from)
+    fn request<T: IntoUrl, Resp: DeserializeOwned>(&self, request: RequestBuilder) -> PocketResult<Resp> {
+        request.send()
+            .map_err(From::from)
             .and_then(|mut r| match r.headers.get::<XErrorCode>().map(|v| v.0) {
                 None => {
                     let mut out = String::new();
                     r.read_to_string(&mut out).map_err(From::from).map(|_| out)
                 },
                 Some(code) => Err(PocketError::Proto(code, r.headers.get::<XError>().map(|v| &*v.0)
-                                                     .unwrap_or("unknown protocol error").to_string())),
+                    .unwrap_or("unknown protocol error").to_string())),
             })
-            .and_then(|s| json::decode::<Resp>(&*s).map_err(From::from))
+            .and_then(|s| serde_json::from_str(&*s).map_err(From::from))
+    }
+
+    fn get_request<T: IntoUrl, Resp: DeserializeOwned>(&self, url: T) -> PocketResult<Resp> {
+        self.request::<T, Resp>(self.client.get(url))
+    }
+
+    fn post_request<T: IntoUrl, Resp: DeserializeOwned>(&self, url: T, data: &str) -> PocketResult<Resp> {
+        let app_json: Mime = "application/json".parse().unwrap();
+
+        self.request::<T, Resp>(self.client
+            .post(url)
+            .body(data)
+            .header(ContentType(app_json.clone()))
+            .header(XAccept(app_json.clone()))
+        )
     }
 
     pub fn get_auth_url(&mut self) -> PocketResult<Url> {
-        let request = try!(json::encode(&PocketOAuthRequest {
+        let request = serde_json::to_string(&PocketOAuthRequest {
             consumer_key: &*self.consumer_key,
             redirect_uri: "rustapi:finishauth",
             state: None
-        }));
+        })?;
 
-        self.request("https://getpocket.com/v3/oauth/request", &*request)
+        self.post_request("https://getpocket.com/v3/oauth/request", &*request)
             .and_then(|r: PocketOAuthResponse| {
                 let mut url = Url::parse("https://getpocket.com/auth/authorize").unwrap();
-                url.set_query_from_pairs(vec![("request_token", &*r.code), ("redirect_uri", "rustapi:finishauth")].into_iter());
+                url.query_pairs_mut().extend_pairs(vec![("request_token", &*r.code), ("redirect_uri", "rustapi:finishauth")].into_iter());
                 self.code = Some(r.code);
                 Ok(url)
             })
     }
 
     pub fn authorize(&mut self) -> PocketResult<String> {
-        let request = try!(json::encode(&PocketAuthorizeRequest {
+        let request = serde_json::to_string(&PocketAuthorizeRequest {
             consumer_key: &*self.consumer_key,
             code: self.code.as_ref().map(|v| &**v).unwrap()
-        }));
+        })?;
 
-        match self.request("https://getpocket.com/v3/oauth/authorize", &*request)
+        match self.post_request("https://getpocket.com/v3/oauth/authorize", &*request)
         {
             Ok(r @ PocketAuthorizeResponse {..}) => {
                 self.access_token = Some(r.access_token);
@@ -956,46 +781,447 @@ impl Pocket {
         }
     }
 
-    pub fn add<T: IntoUrl>(&mut self, url: T, title: Option<&str>, tags: Option<&str>, tweet_id: Option<&str>) -> PocketResult<PocketAddedItem> {
-        let request = try!(json::encode(&PocketAddRequest {
+    pub fn add<T: IntoUrl>(&self, url: T, title: Option<&str>, tags: Option<&str>, tweet_id: Option<&str>) -> PocketResult<PocketAddedItem> {
+        let data = serde_json::to_string(&PocketUserRequest {
             consumer_key: &*self.consumer_key,
             access_token: &**self.access_token.as_ref().unwrap(),
-            url: &url.into_url().unwrap(),
-            title: title.map(|v| v.clone()),
-            tags: tags.map(|v| v.clone()),
-            tweet_id: tweet_id.map(|v| v.clone())
-        }));
+            request: &PocketAddRequest {
+                url: url.into_url().unwrap(),
+                title: title.map(|v| v.clone()),
+                tags: tags.map(|v| v.clone()),
+                tweet_id: tweet_id.map(|v| v.clone())
+            }
+        })?;
 
-        self.request("https://getpocket.com/v3/add", &*request)
+        self.post_request("https://getpocket.com/v3/add", &data)
             .map(|v: PocketAddResponse| v.item)
+    }
+
+    pub fn get(&self, request: &PocketGetRequest) -> PocketResult<Vec<PocketItem>> {
+        let data = serde_json::to_string(&PocketUserRequest {
+            consumer_key: &*self.consumer_key,
+            access_token: &**self.access_token.as_ref().unwrap(),
+            request
+        })?;
+
+        self.post_request("https://getpocket.com/v3/get", &data)
+            .map(|v: PocketGetResponse| v.list)
+    }
+
+    pub fn send(&self, request: &PocketSendRequest) -> PocketResult<PocketSendResponse> {
+        let data = serde_json::to_string(request.actions)?;
+
+        let params = &[
+            ("consumer_key", &*self.consumer_key),
+            ("access_token", &**self.access_token.as_ref().unwrap()),
+            ("actions", &data)
+        ];
+
+        let mut url = "https://getpocket.com/v3/send".into_url().unwrap();
+        url.query_pairs_mut().extend_pairs(params.into_iter());
+
+        self.get_request(url)
     }
 
     #[inline] pub fn push<T: IntoUrl>(&mut self, url: T) -> PocketResult<PocketAddedItem> {
         self.add(url, None, None, None)
     }
 
-    pub fn filter(&mut self) -> PocketGetRequest {
-        PocketGetRequest::new(self)
+    pub fn filter(&self) -> PocketGetRequest {
+        PocketGetRequest::new()
     }
 }
 
-#[test]
-fn test_actions_serialize() {
-    let mut pocket = Pocket::new("abc", Some("def"));
-    let add_action = PocketAddAction {
-        item_id: None,
-        ref_id: None,
-        tags: None,
-        time: None,
-        title: None,
-        url: None
-    };
-    let act: &PocketAction = &add_action;
-    let actions = PocketSendRequest {
-        pocket: &mut pocket,
-        actions: &[act]
-    };
-    //assert_eq!(&*actions.to_json().to_string(), "{
+fn option_from_str<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+    where T: FromStr,
+          T::Err:Display,
+          D: Deserializer<'de>
+{
+    let result: Result<T, D::Error> = from_str(deserializer);
+    result.map(Option::from)
+}
 
-    //}");
+// https://github.com/serde-rs/json/issues/317
+fn from_str<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where T: FromStr,
+          T::Err:Display,
+          D: Deserializer<'de>
+{
+    let s = String::deserialize(deserializer)?;
+    T::from_str(&s).map_err(serde::de::Error::custom)
+}
+
+fn optional_to_string<T, S>(x: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where T: ToString,
+          S: Serializer
+{
+    match x {
+        Some(ref value) => to_string(value, serializer),
+        None => serializer.serialize_none()
+    }
+}
+
+fn to_string<T, S>(x: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where T: ToString,
+          S: Serializer
+{
+    serializer.serialize_str(&x.to_string())
+}
+
+fn optional_vec_from_map<'de, T, D>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
+    where T: Deserialize<'de> + Clone + std::fmt::Debug,
+          D: Deserializer<'de>
+{
+    let m: Option< HashMap<String, T>> = Option::deserialize(deserializer)?;
+    Ok(m.map(map_to_vec))
+}
+
+fn vec_from_map<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+    where T: Deserialize<'de> + Clone + std::fmt::Debug,
+          D: Deserializer<'de>
+{
+    let map: HashMap<String, T> = HashMap::deserialize(deserializer)?;
+    let result = map_to_vec(map);
+
+    Ok(result)
+}
+
+fn map_to_vec<T>(map: HashMap<String, T>) -> Vec<T>
+    where T: Clone + std::fmt::Debug
+{
+    let mut result = vec![];
+    let mut kvs = map.iter().collect::<Vec<_>>();
+    // TODO - items have a sort id, images and such have and index - rethink this sort, possibly a better map type?
+    kvs.sort_by(|&a, &b| a.0.cmp(b.0) );
+
+    for (_, v) in kvs {
+        result.push(v.clone());
+    }
+
+    result
+}
+
+// https://github.com/serde-rs/serde/issues/1344
+fn bool_from_int<'de, D>(deserializer: D) -> Result<bool, D::Error>
+    where
+        D: Deserializer<'de>,
+{
+    match String::deserialize(deserializer)?.as_str() {
+        "0" => Ok(false),
+        "1" => Ok(true),
+        other => Err(serde::de::Error::invalid_value(
+            Unexpected::Str(other),
+            &"zero or one",
+        )),
+    }
+}
+
+fn optional_bool_to_int<S>(x: &Option<bool>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+{
+    match x {
+        Some(ref value) => bool_to_int(value, serializer),
+        None => serializer.serialize_none()
+    }
+}
+
+fn optional_datetime_to_int<S>(x: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+{
+    match x {
+        Some(ref value) => date_unix_timestamp_format::serialize(value, serializer),
+        None => serializer.serialize_none()
+    }
+}
+
+fn untagged_to_str<S>(serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+{
+    serializer.serialize_str("_untagged_")
+}
+
+// inspired by https://serde.rs/custom-date-format.html
+mod date_unix_timestamp_format {
+    use chrono::{DateTime, Utc, TimeZone};
+    use serde::{self, Deserialize, Serializer, Deserializer};
+
+    pub fn serialize<S>(
+        date: &DateTime<Utc>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        serializer.serialize_str(&date.timestamp().to_string())
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<DateTime<Utc>, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<i64>()
+            .map(|i| Utc.timestamp(i, 0))
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+fn bool_to_int<S>(x: &bool, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+{
+    let output = match x {
+        true => "1",
+        false => "0",
+    };
+    serializer.serialize_str(output)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde::Serialize;
+
+    // Auth
+    #[test]
+    fn test_serialize_auth_request() {
+        let request = &PocketOAuthRequest {
+            consumer_key: "consumer_key",
+            redirect_uri: "http://localhost",
+            state: Some("state"),
+        };
+
+        let actual = serde_json::to_string(request).unwrap();
+
+        let expected = remove_whitespace(&format!(r#"
+                    {{
+                        "consumer_key": "{consumer_key}",
+                        "redirect_uri": "{redirect_uri}",
+                        "state": "{state}"
+                    }}
+               "#,
+              consumer_key = request.consumer_key,
+              redirect_uri = request.redirect_uri,
+              state = request.state.unwrap()
+        ));
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_deserialize_auth_response() {
+        let expected = PocketOAuthResponse {
+            code: "code".to_string(),
+            state: Some("state".to_string()),
+        };
+        let response = remove_whitespace(&format!(r#"
+                    {{
+                        "code": "{code}",
+                        "state": "{state}"
+                    }}
+               "#,
+              code = expected.code,
+              state = expected.state.as_ref().unwrap()
+        ));
+
+        let actual: PocketOAuthResponse = serde_json::from_str(&response).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_serialize_authorize_request() {
+        let request = &PocketAuthorizeRequest {
+            consumer_key: "consumer_key",
+            code: "code",
+        };
+
+        let actual = serde_json::to_string(request).unwrap();
+
+        let expected = remove_whitespace(&format!(r#"
+                    {{
+                        "consumer_key": "{consumer_key}",
+                        "code": "{code}"
+                    }}
+               "#,
+              consumer_key = request.consumer_key,
+              code = request.code
+        ));
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_deserialize_authorize_response() {
+        let expected = PocketAuthorizeResponse {
+            access_token: "access_token".to_string(),
+            username: "username".to_string(),
+        };
+        let response = remove_whitespace(&format!(r#"
+                    {{
+                        "access_token": "{access_token}",
+                        "username": "{username}"
+                    }}
+               "#,
+              access_token = expected.access_token,
+              username = expected.username
+        ));
+
+        let actual: PocketAuthorizeResponse = serde_json::from_str(&response).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    fn remove_whitespace(s: &String) -> String {
+        s.replace(|c: char| c.is_whitespace(), "")
+    }
+
+    // Get
+    // PocketGetRequest
+    #[test]
+    fn test_serialize_get_request() {
+        let request = &PocketGetRequest {
+            search: Some("search"),
+            domain: Some("domain"),
+
+            tag: Some(PocketGetTag::Untagged),
+            state: Some(PocketGetState::All),
+            content_type: Some(PocketGetType::Article),
+            detail_type: Some(PocketGetDetail::Complete),
+            favorite: Some(false),
+            since: Some(Utc::now()),
+
+            sort: Some(PocketGetSort::Newest),
+            count: Some(1),
+            offset: Some(2)
+        };
+
+        let actual = serde_json::to_string(request).unwrap();
+
+        let expected = remove_whitespace(&format!(r#"
+                    {{
+                        "search": "{search}",
+                        "domain": "{domain}",
+                        "tag": "{tag}",
+                        "state": "{state}",
+                        "content_type": "{content_type}",
+                        "detail_type": "{detail_type}",
+                        "favorite": "{favorite}",
+                        "since": "{since}",
+                        "sort": "{sort}",
+                        "count": "{count}",
+                        "offset": "{offset}"
+                    }}
+               "#,
+                  search = request.search.unwrap(),
+                  domain = request.domain.unwrap(),
+                  tag = to_inner_json_string(&request.tag.as_ref()),
+                  state = to_inner_json_string(&request.state.unwrap()),
+                  content_type = to_inner_json_string(&request.content_type.unwrap()),
+                  detail_type = to_inner_json_string(&request.detail_type.unwrap()),
+                  favorite = if request.favorite.unwrap() { 1 } else { 0 },
+                  since = request.since.unwrap().timestamp().to_string(),
+                  sort = to_inner_json_string(&request.sort.unwrap()),
+                  count = request.count.unwrap(),
+                  offset = request.offset.unwrap(),
+        ));
+
+        assert_eq!(actual, expected);
+    }
+
+    fn to_inner_json_string<T: Serialize>(value: T) -> String {
+        serde_json::to_value(value).unwrap()
+            .as_str().unwrap()
+            .trim_matches('\"')
+            .to_string()
+    }
+
+    // PocketGetDetail
+    // PocketGetSort
+    // PocketGetState
+    // PocketGetTag
+    // PocketGetType
+    // ItemVideo
+    // PocketItemHas
+
+    // ItemImage
+    #[test]
+    fn test_deserialize_item_image() {
+        let expected = ItemImage {
+            item_id: 1,
+            image_id: 2,
+            src: "http://localhost".into_url().unwrap(),
+            width: 3,
+            height: 4,
+            caption: "caption".to_string(),
+            credit: "credit".to_string(),
+        };
+        let response = remove_whitespace(&format!(r#"
+                    {{
+                        "item_id": "{item_id}",
+                        "image_id": "{image_id}",
+                        "src": "{src}",
+                        "width": "{width}",
+                        "height": "{height}",
+                        "caption": "{caption}",
+                        "credit": "{credit}"
+                    }}
+               "#,
+              item_id = expected.item_id,
+              image_id = expected.image_id,
+              src = expected.src,
+              width = expected.width,
+              height = expected.height,
+              caption = expected.caption,
+              credit = expected.credit,
+        ));
+
+        let actual: ItemImage = serde_json::from_str(&response).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    // PocketSendAction
+    // PocketSendRequest
+    // PocketSendResponse
+
+    // PocketAddRequest
+    #[test]
+    fn test_serialize_add_request() {
+        let request = &PocketAddRequest {
+            url: "http://localhost".into_url().unwrap(),
+            title: Some("title"),
+            tags: Some("tags"),
+            tweet_id: Some("tweet_id"),
+        };
+
+        let actual = serde_json::to_string(request).unwrap();
+
+        let expected = remove_whitespace(&format!(r#"
+                    {{
+                        "url": "{url}",
+                        "title": "{title}",
+                        "tags": "{tags}",
+                        "tweet_id": "{tweet_id}"
+                    }}
+               "#,
+              url = request.url,
+              title = request.title.unwrap(),
+              tags = request.tags.unwrap(),
+              tweet_id = request.tweet_id.unwrap(),
+        ));
+
+        assert_eq!(actual, expected);
+    }
+
+    // PocketAddedItem
+    // PocketAddResponse
+    // PocketGetResponse
+    // PocketItemStatus
+    // PocketItem
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -822,7 +822,7 @@ impl Pocket {
         self.get_request(url)
     }
 
-    #[inline] pub fn push<T: IntoUrl>(&mut self, url: T) -> PocketResult<PocketAddedItem> {
+    #[inline] pub fn push<T: IntoUrl>(&self, url: T) -> PocketResult<PocketAddedItem> {
         self.add(url, None, None, None)
     }
 


### PR DESCRIPTION
 Major changes to get send, add, and get endpoints working.

Changes:
- Update version of hyper
- Change serialization lib from rustc-serialize to serde
- Change time lib from time to chrono
- Support send/modify endpoint
- Replace 'try!' with '?'
- Change some access modifiers for structs mostly for usability
- Change send/modify actions from struct to enum
- Start to remove the need for `Pocket` to be mutable
- Add some (but not enough( tests around serializing and deserializing
- Add separate examples for add, auth, modify, and retrieve