### PR TITLE
Map to vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Deserializer, Serializer, Serialize};
 use serde::de::{DeserializeOwned, Unexpected};
 use std::str::FromStr;
 use std::fmt::Display;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use chrono::{DateTime, Utc};
 use hyper::net::HttpsConnector;
 use serde_json::Value;
@@ -961,7 +961,7 @@ fn json_value_to_vec<'de, T, D>(value: Value) -> Result<Vec<T>, D::Error>
                 .map_err(serde::de::Error::custom)
         },
         o @ Value::Object(..) => {
-            serde_json::from_value::<HashMap<String, T>>(o)
+            serde_json::from_value::<BTreeMap<String, T>>(o)
                 .map(map_to_vec)
                 .map_err(serde::de::Error::custom)
         },
@@ -972,19 +972,8 @@ fn json_value_to_vec<'de, T, D>(value: Value) -> Result<Vec<T>, D::Error>
     }
 }
 
-fn map_to_vec<T>(map: HashMap<String, T>) -> Vec<T>
-    where T: Clone + std::fmt::Debug
-{
-    let mut result = vec![];
-    let mut kvs = map.iter().collect::<Vec<_>>();
-    // TODO - items have a sort id, images and such have and index - rethink this sort, possibly a better map type?
-    kvs.sort_by(|&a, &b| a.0.cmp(b.0) );
-
-    for (_, v) in kvs {
-        result.push(v.clone());
-    }
-
-    result
+fn map_to_vec<T>(map: BTreeMap<String, T>) -> Vec<T> {
+    map.into_iter().map(|(_, v)| v).collect::<Vec<_>>()
 }
 
 // https://github.com/serde-rs/serde/issues/1344


### PR DESCRIPTION
PocketGetResponse fails to deserialize when there are not results in the `list` field. This occurs because the Pocket API returns an empty array instead of an object for the `list` value. The current implementation of `vec_from_map` expects the `list` value to always be a object.

Example empty array response
```
{
    "status": 2,
    "complete": 1,
    "list": [],
    "error": null,
    "search_meta": {
        "search_type": "normal"
    },
    "since": 1584221436
}
```

vs the non-empty object response
```
{
    "status": 1,
    "complete": 1,
    "list": {
        "2525529900": {
            "item_id": "2525529900",
            ...
    },
    "error": null,
    "search_meta": {
        "search_type": "normal"
    },
    "since": 1584289972
}
```

This merge request updates vec_from_map to handle both a map and array. 

This MR also changes the underlying `vec_from_map` conversion to use BTreeMap instead of sorting the map by keys. This sorting was causing results in the list to be rearranged during deserialization, thereby breaking any sorting done by Pocket API.
