### PR TITLE
Domain metadata name optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ pub struct ItemImage {
 
 #[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct DomainMetaData {
-    pub name: String,
+    pub name: Option<String>,
     pub logo: String,
     pub greyscale_logo: String,
 }


### PR DESCRIPTION
In some cases the `DomainMetaData`.`name` is not provided in some items returned by the Pocket Get endpoint. This MR makes the field optional.