### PR TITLE
Make ItemTag fields public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,8 +247,8 @@ pub struct DomainMetaData {
 #[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct ItemTag {
     #[serde(deserialize_with = "from_str")]
-    item_id: u64,
-    tag: String,
+    pub item_id: u64,
+    pub tag: String,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Clone)]


### PR DESCRIPTION
Change ItemTag fields from private to public so they can be used outside the crate. This access is inline with the other structs returned from `Pocket`.