### PR TITLE
Update response fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_derive = "1.0"
 url_serde = "0.2.0"
-mime = "0.2"
 
 [dev-dependencies]
 log = "0.3.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,12 +351,12 @@ pub struct PocketAddedItem {
 
     #[serde(deserialize_with = "option_string_date_unix_timestamp_format")]
     pub time_first_parsed: Option<DateTime<Utc>>,
-    #[serde(default)]
-    pub authors: Vec<ItemAuthor>,
-    #[serde(default)]
-    pub images: Vec<ItemImage>,
-    #[serde(default)]
-    pub videos: Vec<ItemVideo>,
+    #[serde(default, deserialize_with = "optional_vec_from_map")]
+    pub authors: Option<Vec<ItemAuthor>>,
+    #[serde(default, deserialize_with = "optional_vec_from_map")]
+    pub images: Option<Vec<PocketImage>>,
+    #[serde(default, deserialize_with = "optional_vec_from_map")]
+    pub videos: Option<Vec<ItemVideo>>,
 
     #[serde(default, deserialize_with = "try_url_from_string")]
     pub resolved_normal_url: Option<Url>,
@@ -1447,9 +1447,9 @@ mod test {
                 used_fallback: true,
                 lang: Some("".to_string()),
                 time_first_parsed: None,
-                authors: vec![],
-                images: vec![],
-                videos: vec![],
+                authors: Some(vec![]),
+                images: Some(vec![]),
+                videos: Some(vec![]),
                 resolved_normal_url: "http://example.com".into_url().ok(),
                 given_url: "https://example.com".into_url().unwrap(),
             },
@@ -1527,9 +1527,9 @@ mod test {
                 used_fallback: false,
                 lang: None,
                 time_first_parsed: None,
-                authors: vec![],
-                images: vec![],
-                videos: vec![],
+                authors: None,
+                images: None,
+                videos: None,
                 resolved_normal_url: None,
                 given_url: "https://dc7ad3b2-942e-41c5-9154-a1b545752102.com".into_url().unwrap(),
             },


### PR DESCRIPTION
Add _missing_ `PocketAddedItem` fields, change some fields to more applicable types, and test `PocketAddResponse` with a resolved and unresolved response.

Add
- `resolved_normal_url`
- `time_first_parsed`
- `innerdomain_redirect`

More applicable types
- `date_published`
- `date_resolved`
- `mime_type`

Changed as a result of testing
- `resolved_url` 
- `videos`
- `authors`
- `images`
- `lang`

Removed `mime` crate in favor of using hyper's reexport.

