### PR TITLE
Optional Values in GetPocket API

### DIFF
--- a/examples/add.rs
+++ b/examples/add.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let url = Url::parse("https://example.com")?;
     let item = pocket
         .add(
-            &PocketAddRequest::new(&url)
+            PocketAddRequest::new(&url)
                 .title("Example title")
                 .tags(&["example-tag"])
                 .tweet_id("example_tweet_id"),

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,7 +1,5 @@
 use pocket::auth::PocketAuthentication;
-use std::error::Error;
-use std::io;
-use std::time::Instant;
+use std::{error::Error, io, time::Instant};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/examples/modify.rs
+++ b/examples/modify.rs
@@ -1,7 +1,10 @@
 extern crate hyper;
 extern crate pocket;
 
-use pocket::{send::PocketSendAction, send::PocketSendRequest, Pocket};
+use pocket::{
+    send::{PocketSendAction, PocketSendRequest},
+    Pocket,
+};
 use std::error::Error;
 use url::Url;
 

--- a/src/add.rs
+++ b/src/add.rs
@@ -1,5 +1,4 @@
-use crate::serialization::*;
-use crate::{ItemAuthor, ItemVideo, PocketImage, PocketItemHas};
+use crate::{serialization::*, ItemAuthor, ItemVideo, PocketImage, PocketItemHas};
 use chrono::{DateTime, Utc};
 use mime::Mime;
 use serde::{Deserialize, Serialize};
@@ -240,7 +239,7 @@ mod test {
               }
          "#;
 
-        let actual: PocketAddResponse = serde_json::from_str(&response).unwrap();
+        let actual: PocketAddResponse = serde_json::from_str(response).unwrap();
 
         assert_eq!(actual, expected);
     }
@@ -316,7 +315,7 @@ mod test {
               }
          "#;
 
-        let actual: PocketAddResponse = serde_json::from_str(&response).unwrap();
+        let actual: PocketAddResponse = serde_json::from_str(response).unwrap();
 
         assert_eq!(actual, expected);
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,4 @@
-use crate::client::PocketClient;
-use crate::errors::PocketError;
-use crate::Pocket;
-use crate::PocketResult;
+use crate::{client::PocketClient, errors::PocketError, Pocket, PocketResult};
 use serde::{Deserialize, Serialize};
 use url::Url;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,16 +1,16 @@
-use crate::errors::PocketError;
-use crate::headers::{HEADER_XACCEPT, HEADER_XERROR, HEADER_XERROR_CODE};
-use crate::PocketResult;
+use crate::{
+    errors::PocketError,
+    headers::{HEADER_XACCEPT, HEADER_XERROR, HEADER_XERROR_CODE},
+    PocketResult,
+};
 use bytes::buf::BufExt as _;
 use futures::TryFutureExt;
-use hyper::client::{Client, HttpConnector};
-use hyper::Body;
-use hyper::Method;
-use hyper::Request;
-use hyper::Uri;
+use hyper::{
+    client::{Client, HttpConnector},
+    Body, Method, Request, Uri,
+};
 use hyper_tls::HttpsConnector;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 use std::convert::{From, TryFrom};
 
 pub struct PocketClient {

--- a/src/get.rs
+++ b/src/get.rs
@@ -198,9 +198,10 @@ pub struct PocketItem {
     #[serde(default, deserialize_with = "try_url_from_string")]
     pub given_url: Option<Url>,
     pub given_title: String,
-    #[serde(deserialize_with = "from_str")]
-    pub word_count: usize,
-    pub excerpt: String,
+    #[serde(default)]
+    pub word_count: Option<String>,
+    #[serde(default)]
+    pub excerpt: Option<String>,
     #[serde(with = "string_date_unix_timestamp_format")]
     pub time_added: DateTime<Utc>,
     #[serde(deserialize_with = "option_string_date_unix_timestamp_format")]
@@ -211,15 +212,17 @@ pub struct PocketItem {
     pub time_favorited: Option<DateTime<Utc>>,
     #[serde(deserialize_with = "bool_from_int_string")]
     pub favorite: bool,
-    #[serde(deserialize_with = "bool_from_int_string")]
+    #[serde(default, deserialize_with = "bool_from_optional_str")]
     pub is_index: bool,
-    #[serde(deserialize_with = "bool_from_int_string")]
+    #[serde(default, deserialize_with = "bool_from_optional_str")]
     pub is_article: bool,
-    pub has_image: PocketItemHas,
-    pub has_video: PocketItemHas,
+    #[serde(default)]
+    pub has_image: Option<PocketItemHas>,
+    #[serde(default)]
+    pub has_video: Option<PocketItemHas>,
     #[serde(deserialize_with = "from_str")]
     pub resolved_id: u64,
-    pub resolved_title: String,
+    pub resolved_title: Option<String>,
     #[serde(default, deserialize_with = "try_url_from_string")]
     pub resolved_url: Option<Url>,
     pub sort_id: u64,
@@ -232,7 +235,7 @@ pub struct PocketItem {
     pub videos: Option<Vec<ItemVideo>>,
     #[serde(default, deserialize_with = "optional_vec_from_map")]
     pub authors: Option<Vec<ItemAuthor>>,
-    pub lang: String,
+    pub lang: Option<String>,
     pub time_to_read: Option<u64>,
     pub domain_metadata: Option<DomainMetaData>,
     pub listen_duration_estimate: Option<u64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,11 @@ use client::PocketClient;
 use errors::PocketError;
 use futures::TryFutureExt;
 use get::*;
-use hyper::http::uri::InvalidUri;
-use hyper::Uri;
+use hyper::{http::uri::InvalidUri, Uri};
 use send::*;
 use serde::{Deserialize, Serialize};
 use serialization::*;
-use std::convert::TryInto;
-use std::result::Result;
+use std::{convert::TryInto, result::Result};
 use url::Url;
 
 pub mod add;

--- a/src/send.rs
+++ b/src/send.rs
@@ -154,7 +154,7 @@ mod test {
             }
         "#;
 
-        let actual: PocketSendResponse = serde_json::from_str(&response).unwrap();
+        let actual: PocketSendResponse = serde_json::from_str(response).unwrap();
 
         assert_eq!(actual, expected);
     }
@@ -231,13 +231,13 @@ mod test {
                     "lang":"",
                     "time_first_parsed":"0",
                     "authors":[
-            
+
                     ],
                     "images":[
-            
+
                     ],
                     "videos":[
-            
+
                     ],
                     "resolved_normal_url":"http://example.com",
                     "given_url":"https://example.com/"
@@ -250,7 +250,7 @@ mod test {
             }
         "#;
 
-        let actual: PocketSendResponse = serde_json::from_str(&response).unwrap();
+        let actual: PocketSendResponse = serde_json::from_str(response).unwrap();
 
         assert_eq!(actual, expected);
     }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,12 +1,11 @@
 use chrono::{DateTime, TimeZone, Utc};
 use mime::Mime;
-use serde::de::{DeserializeOwned, Unexpected};
-use serde::{Deserialize, Deserializer, Serializer};
+use serde::{
+    de::{DeserializeOwned, Unexpected},
+    Deserialize, Deserializer, Serializer,
+};
 use serde_json::Value;
-use std::collections::BTreeMap;
-use std::fmt::Display;
-use std::result::Result;
-use std::str::FromStr;
+use std::{collections::BTreeMap, fmt::Display, result::Result, str::FromStr};
 use url::Url;
 
 pub fn option_from_str<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
@@ -150,7 +149,22 @@ where
         None => serializer.serialize_none(),
     }
 }
-
+pub fn bool_from_optional_str<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match String::deserialize(deserializer)?
+        .parse()
+        .expect("failed to parse bool input")
+    {
+        0 => Ok(false),
+        1 => Ok(true),
+        other => Err(serde::de::Error::invalid_value(
+            Unexpected::Unsigned(other as u64),
+            &"zero or one",
+        )),
+    }
+}
 pub fn optional_datetime_to_int<S>(
     x: &Option<DateTime<Utc>>,
     serializer: S,


### PR DESCRIPTION
- While using the library, I faced some issues with fields that are not
present from GetPocket so I changed those to optionals.

- created a local `rustfmt.toml` to ignore my default `nightly` configs